### PR TITLE
ユーザー登録ページからname,email,passwordでユーザー登録できるようにしました

### DIFF
--- a/app/controllers/user_pages_controller.rb
+++ b/app/controllers/user_pages_controller.rb
@@ -1,0 +1,4 @@
+class UserPagesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+   before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+   def new
+     super
+   end
+
+  # POST /resource
+   def create
+     super
+   end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+   protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+   def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+   end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/views/user_pages/index.html.erb
+++ b/app/views/user_pages/index.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.present? %>
+    <p>Welcome! <%= current_user.name %>さん</p>
+<% else %>
+    <p>Hello! ゲストさん</p>
+<% end %>
+<h1>UserPages#index</h1>
+<p>Find me in app/views/user_pages/index.html.erb</p>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,0 +1,34 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+   config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users
+  root 'user_pages#index'
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
+  }
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20210615060447_add_name_to_users.rb
+++ b/db/migrate/20210615060447_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_172239) do
+ActiveRecord::Schema.define(version: 2021_06_15_060447) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_172239) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## やったこと
* usersテーブルにnameカラムを追加しsign_upページからユーザー登録できるようにしました。

## 動作確認
* ブラウザから登録が可能かどうか
### 作業手順
1. name, email, password, password confirmationの４項目を全て入力
2. user_pages/indexにアクセスされ、追記したコメントが反映されることを確認

## その他
作業がたくさんになってしまいましたが、ユーザー登録ができるところで区切りがいいと思いましたのでこの粒度で提出しました。
また、今回の変更内容が #1 の内容に依存しますので、マージ先を #1 にしています。先に #1 をご確認ください。

## PRを作るにあたり実施したこと(自分用メモ)

1. `rails g controller UserPages index`を実行してユーザーページを作成
2. user_pages#indexをrootに設定（sign_upしたのちrootへ自動的にアクセスするため）
3. `rails g migration add_name_to_users name:string`を実行
4. nameカラムに`null: false`を追加
5. `rails db:migrate:reset`を実行
6. `rails dbconsole`にて`.schema`を実行、nameカラムの後ろにNOT NULLを確認
4. `rails g devise:controllers users`を実行、下記をroutes.rbに追記（veiwの変更を反映させるため。例えばここに`registrations: 'users/registrations',`の記載がないと、veiwの変更が反映されません。）
```
devise_for :users, controllers: {
    registrations: 'users/registrations',
    sessions: 'users/sessions'
  }
```
4. `rails g devise:views users`を実行
5. `registrations/new.html.erb`にname記載用のtext_fieldを記載
```
<h2>Sign up</h2>

<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
  <%= render "users/shared/error_messages", resource: resource %>

#追記始まり
  <div class="field">
    <%= f.label :name %><br />
    <%= f.text_field :name, autofocus: true %>
  </div>
#追記終わり
```
6. `registrations_controller.rb`にて下記を追記（これの追記によりユーザー登録の条件にnameが追加されるため）
```
class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]　　#追記部分1

-----省略-------

  protected  
# If you have extra params to permit, append them to the sanitizer.   
　def configure_sign_up_params    
　　devise_parameter_sanitizer.permit(:sign_up, keys: [:name])　#追記部分2
　　devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])   
　end
```
7. `user_pages/index.html.erb` にて、ユーザー登録ができた後、ユーザーページにログインされた時に登録したnameが表示されるよう追記
